### PR TITLE
unescape question mark

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const {join} = require('path')
 const {homedir} = require('os');
 const fs = require('fs')
 
-const kebabize = (str) => 
+const kebabize = (str) =>
   str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? "-" : "") + $.toLowerCase())
 
-const wagmiKnownChains = {} 
+const wagmiKnownChains = {}
 
 function readConfigFile(path) {
   const prefix = '.chains';
@@ -53,13 +53,17 @@ for (const chain of Object.keys(wagmiChains)) {
   wagmiKnownChains[kebabize(chain)] = updateChainConfig(wagmiChains[chain]);
 }
 
+function escapeVerifierUrl(url) {
+  return url.replace("\\?", "?");
+}
+
 function forge(config, args) {
   if (args.verify) {
     const command = [`--chain ${config.id}`];
     if (config.etherscanApiKey) {
       command.push(`--etherscan-api-key ${config.etherscanApiKey}`);
     } else {
-      command.push(`--verifier-url ${config.verifierUrl} --verifier blockscout`);
+      command.push(`--verifier-url ${escapeVerifierUrl(config.verifierUrl)} --verifier blockscout`);
     }
     console.log(command.join(' '));
     return;
@@ -68,7 +72,7 @@ function forge(config, args) {
   if (args.deploy) {
     const command = [`--rpc-url ${config.rpcUrl}`];
     if (config.verifierUrl) {
-      command.push(`--verifier-url ${config.verifierUrl} --verifier blockscout`);
+      command.push(`--verifier-url ${escapeVerifierUrl(config.verifierUrl)} --verifier blockscout`);
     }
     if (config.etherscanApiKey) {
       command.push(`--etherscan-api-key ${config.etherscanApiKey}`);


### PR DESCRIPTION
forge verification breaks when running the chains command and the verification url has a "\?" in it.

For example, this breaks:
`forge verify-contract 0x2914653da4fb4f6e381e56a86425eecb21f588a7 ZoraCreator1155Attribution $(chains zora-testnet --verify)`
with the error "Response result is unexpectedly empty: status=0, message=Something went wrong."

echoing the output of `$(chains zora-testnet --verify)` produces running  `echo $(chains zora-testnet --verify)` produces `--chain 999 --verifier-url https://testnet.explorer.zora.energy/api\? --verifier blockscout`

and if you manually copy and paste that to the verify-contract command it works:
`forge verify-contract 0x2914653da4fb4f6e381e56a86425eecb21f588a7 ZoraCreator1155Attribution --verifier blockscout  --verifier-url https://testnet.explorer.zora.energy/api\?`

The node.js script needs to unescape the backslash; I've tried this fix locally with my locally installed `chains` package, and it works. 